### PR TITLE
Use better character encoding, include all frequencies

### DIFF
--- a/rds.py
+++ b/rds.py
@@ -7,19 +7,21 @@ import telnetlib
 now = pd.Timestamp.now(tz="US/Pacific")  # .tz_convert('utc')
 print(now)
 
+DEFAULT_DPSTR = "KSQD 90.7 FM, 89.7 FM, 89.5 FM, and ksqd.org"
+
 try:
     df = pd.read_sql_query(
         f"select * from shows where start < datetime('{now}') and end > datetime('{now}') order by start",
         "sqlite:///../twoweekarchive/shows.db",
     )
     if len(df) > 0:
-        dpsstr = f"{df['title'][0]} on KSQD 90.7 and ksqd.org"
+        dpsstr = f"{df['title'][0]} on {DEFAULT_DPSTR}"
     else:
         print("sql query did not receive valid results; falling back to default")
-        dpsstr = f"KSQD 90.7 and ksqd.org"
+        dpsstr = DEFAULT_DPSTR
 except sqlalchemy.exc.OperationalError:
     print("invalid sql query; falling back to default")
-    dpsstr = f"KSQD 90.7 and ksqd.org"
+    dpsstr = DEFAULT_DPSTR
 
 print(dpsstr)
 
@@ -27,7 +29,7 @@ with open("ipaddress") as f:
     ip = f.read().strip()
 
 tn = telnetlib.Telnet(ip, port=10001, timeout=10)
-tn.write(f"DPS={dpsstr}\r\n".encode("utf-8"))
+tn.write(f"DPS={dpsstr}\r\n".encode("latin_1"))
 try:
     response = tn.read_until(b"OK", timeout=10)
 except EOFError as e:


### PR DESCRIPTION
RDS uses the IEC 62106-4 character encoding, which is closer to ISO Latin-1 than it is to UTF-8.

KSQD now has multiple frequencies, so list them all.  And put the default DP text in a constant.

UNTESTED - for obvious reasons.